### PR TITLE
Wallet Balances API endpoint

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -87,7 +87,12 @@ functions:
       - httpApi:
           path: /addresses/{address}/balance
           method: GET
-
+  balances:
+    handler: src/handler.balances
+    events:
+      - httpApi:
+          path: /addresses/balances/{term}
+          method: GET
 
   currencySnapshots:
     handler: src/handler.currencySnapshots

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,6 +1,7 @@
 import { getClient } from "./opensearch";
 import {
   getBalanceByAddress,
+  getBalances,
   getBlock,
   getCurrencyBalanceByAddress,
   getCurrencyBlock,
@@ -44,6 +45,8 @@ export const transactionsByDestination = (event) =>
   getTransactionsByDestination(event, osClient)();
 export const balanceByAddress = (event) =>
   getBalanceByAddress(event, osClient)();
+export const balances = (event) =>
+  getBalances(event, osClient)();
 
 // Currency
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -20,6 +20,7 @@ import {
 } from "./validation";
 import {
   findBalanceByAddress,
+  findBalances,
   findBlockByHash,
   findSnapshot,
   findSnapshotRewards,
@@ -411,6 +412,27 @@ export const getBalanceByAddress = (
     })),
     chain(({ address, ordinal, currencyIdentifier }) =>
       findBalanceByAddress(os)(address, currencyIdentifier, ordinal)
+    ),
+    fold(
+      (reason) => T.of(errorResponse(reason)),
+      (value) => T.of(successResponse(StatusCodes.OK)(value))
+    )
+  );
+
+export const getBalances = (
+  event: APIGatewayEvent,
+  os: Client
+): Task<Response> =>
+  pipe(
+    of<ApplicationError, APIGatewayEvent>(event),
+    chain(validateTermParam),
+    map(extractTerm),
+    map((params) => ({
+      ...params,
+      ...extractCurrencyIdentifier(event),
+    })),
+    chain(({ termValue, currencyIdentifier }) =>
+      findBalances(os)(currencyIdentifier, termValue)
     ),
     fold(
       (reason) => T.of(errorResponse(reason)),


### PR DESCRIPTION
Adds an API endpoint that returns a list of all wallets and their balances for a certain ordinal.
The endpoint URL is "/addresses/balances/latest" or "/addresses/balances/latest/70" (to get it for a specific ordinal).

I only tested this on tessellation v1.9.1 on my local machine as I couldn't make the snapshot streaming project work for tessellation v2.X instances (probably the readme needs to be updated in the snapshot streaming project to make it work for tess v2.X).

I don't have much in-depth knowledge of typescript, so feel free to make any changes or let me know if there are any remarks.

Example response:

```
{
	"data": [
		{
			"ordinal": 70,
			"balance": 808888888710,
			"address": "DAG0Njmo6JZ3FhkLsipJSppepUHPuTXcSifARfvK"
		},
		{
			"ordinal": 70,
			"balance": 1000000000,
			"address": "DAG0R1CMwfLPNp4qkA2TTqkcKWp3mC7U4ZMD5n1B"
		}		
	],
	"meta": {}
}
```
Referenced issue: #125 